### PR TITLE
Parent POM and Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk: oraclejdk8
+script: mvn clean test package

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ConfigHub</groupId>
+    <artifactId>ConfigHub</artifactId>
+    <version>1.7</version>
+    <name>ConfigHub Parent</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>core</module>
+        <module>rest</module>
+    </modules>
+</project>


### PR DESCRIPTION
This adds [Travis CI][1] build support for verifying pull requests.

It should probably be expanded to include the full packaging method for how releases are published.  Travis CI can automatically publish on tag.

Here's an example build from Travis CI using the parent pom.

https://travis-ci.org/samrocketman/ConfigHubPlatform/builds/349665366

After running `mvn clean test package` there will be a `rest/target/ROOT.war` and `core/target/ConfigHub-Core-1.7.jar`.

[1]: https://docs.travis-ci.com/user/languages/java/