### PR TITLE
Build the docker image in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: java
 jdk: oraclejdk8
-script: mvn clean test package
+sudo: required
+services:
+  - docker
+script:
+  - mvn clean test package
+  - docker build -t confighub -f ./docker/Dockerfile docker/


### PR DESCRIPTION
It makes sense to attempt to build the `Dockerfile` when testing PRs since you have the docker image mixed with this source code.  This adds building the docker image to Travis CI as part of validating pull requests.