### PR TITLE
Adding a new rest API endpoint to get Key definition data

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ programmatically or through the web-based user interface.
    pages/schema/pull
    pages/schema/push
    pages/schema/rawFile
+   pages/schema/keyData
    pages/schema/info
    pages/schema/all
    pages/schema/system

--- a/docs/pages/schema/keyData.rst
+++ b/docs/pages/schema/keyData.rst
@@ -1,0 +1,82 @@
+****************
+Single Key Data Definition Pull
+****************
+
+With a given key name, pull a specific key's definition.
+The response contains a list of key value pairs the given key definition.
+
+- API URL (with token):  ``https://confighub-api/rest/keyData``
+- API URL (no token):  ``https://confighub-api/rest/keyData/<account>/<repository>``
+
+
+.. note:: - All data returned is in JSON format.
+- All dates are expected and returned in ``ISO 8601`` format (UTC): ``YYYY-MM-DDTHH:MM:SSZ``.
+   - All parameters are passed through HTTP header fields.
+   - Returned data is the content of the resolved file.
+   - Method: GET
+
+
+Usage
+-----
+
+.. code-block:: bash
+
+   curl -i https://api.confighub.com/rest/rawFile  \
+        -H "Client-Token: <token>"                 \
+        -H "KeyName: myKeyName"                    \
+        -H "Application-Name: myApp"               \
+        -H "Client-Version: <optional version>"    \
+        -H "Tag: <optional tag label>"             \
+        -H "Repository-Date: <optional repo date>" \
+        -H "Pretty: <optional boolean>" \
+
+
+Request Headers
+---------------
+
+*Client-Token*
+
+   Client token identifies a specific repository. This field is not required if the account and repository
+   are specified as part of the URL.
+
+
+*Repository-Date*
+
+   ISO 8601 date format (UTC) ``YYYY-MM-DDTHH:MM:SSZ`` lets you specify a point in time for which to pull
+   configuration. If not specified, latest configuration is returned.
+
+*Tag*
+
+   Name of the defined tag. Returned configuration is for a point in time as specified by the tag. If both
+   Tag and *Repository-Date* headers are specified, Repository-Date is only used if the tag is no longer
+   available.
+
+*Security-Profile-Auth*
+
+   If a repository is enabled for and uses Security-Profiles (SP) with encryption, choose any of several
+   ways to decrypt resolved property values.
+
+   #. Server-Side decryption by providing SP name(s) and password(s):
+      - Token is created that specifies SP name/password pairs;
+      - SP name/password pairs are specified using this request parameter.
+
+   #. Client-Side decryption is also available by:
+      - Use of ConfigHub API in a selected language come functionality for local decryption;
+      - A client can implement its own decryption;
+
+   Security-Profile-Auth uses JSON format: ``{'Security-Profile_1':'password', 'Security-Profile_2':'password',...}``
+
+*Client-Version*
+
+   Version of the client API. If not specified, ConfigHub assumes the latest version. Even through this is
+   not a required parameter, you are encouraged to specify a version.
+
+
+*Application-Name*
+
+   This field helps you identify application or a client pulling configuration. Visible in Pull Request tab.
+
+*Pretty*
+
+   If value is ``true``, returned JSON is 'pretty' - formatted.
+

--- a/rest/src/main/java/com/confighub/api/repository/client/AClientAccessValidation.java
+++ b/rest/src/main/java/com/confighub/api/repository/client/AClientAccessValidation.java
@@ -159,6 +159,17 @@ public abstract class AClientAccessValidation
         setPasswords(store, repository, token, date, passwords);
     }
 
+    public void validateKeyDataPull(final String clientToken,
+                                    final String version,
+                                    final String appName,
+                                    final String remoteIp,
+                                    Store store)
+            throws ConfigException
+    {
+        checkToken(clientToken, store);
+        setPasswords(store, repository, token, date, passwords);
+    }
+
 
     public void validatePull(String clientToken,
                              String contextString,

--- a/rest/src/main/java/com/confighub/api/repository/client/v1/APIPullKeyData.java
+++ b/rest/src/main/java/com/confighub/api/repository/client/v1/APIPullKeyData.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of ConfigHub.
+ *
+ * ConfigHub is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ConfigHub is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ConfigHub.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.confighub.api.repository.client.v1;
+
+import com.confighub.api.repository.client.AClientAccessValidation;
+import com.confighub.core.error.ConfigException;
+import com.confighub.core.repository.PropertyKey;
+import com.confighub.core.store.Store;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/keyData")
+public class APIPullKeyData
+        extends AClientAccessValidation
+{
+    private static final Logger log = LogManager.getLogger("API");
+
+    @GET
+    @Path("/{account}/{repository}")
+    public Response get(@PathParam("account") String account,
+                        @PathParam("repository") String repositoryName,
+                        @HeaderParam("KeyName") String keyName,
+                        @HeaderParam("Repository-Date") String dateString,
+                        @HeaderParam("Tag") String tagString,
+                        @HeaderParam("Client-Version") String version,
+                        @HeaderParam("Application-Name") String appName,
+                        @HeaderParam("X-Forwarded-For") String remoteIp,
+                        @HeaderParam("Pretty") boolean pretty)
+    {
+
+        Store store = new Store();
+        try
+        {
+            getRepositoryFromUrl(account, repositoryName, tagString, dateString, store, true);
+            validateKeyDataPull(null, version, appName, remoteIp, store);
+            return keyResponse(store.getKey(repository, keyName, date), pretty);
+        }
+        catch (ConfigException e)
+        {
+            log.error("A ConfigException occurred", e);
+            return Response.status(Response.Status.NOT_ACCEPTABLE).tag(e.getMessage()).build();
+        }
+        catch (Exception e)
+        {
+            log.error("An unexpected exception occurred", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).tag(e.getMessage()).build();
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    @GET
+    public Response get(@HeaderParam("Client-Token") String clientToken,
+                        @HeaderParam("KeyName") String keyName,
+                        @HeaderParam("Repository-Date") String dateString,
+                        @HeaderParam("Tag") String tagString,
+                        @HeaderParam("Client-Version") String version,
+                        @HeaderParam("Application-Name") String appName,
+                        @HeaderParam("X-Forwarded-For") String remoteIp,
+                        @HeaderParam("Pretty") boolean pretty)
+    {
+        Store store = new Store();
+
+        try
+        {
+            getRepositoryFromToken(clientToken, dateString, tagString, store);
+            validateKeyDataPull(clientToken, version, appName, remoteIp, store);
+            return keyResponse(store.getKey(repository, keyName, date), pretty);
+        }
+        catch (ConfigException e)
+        {
+            log.error("A ConfigException occurred", e);
+            return Response.status(Response.Status.NOT_ACCEPTABLE).tag(e.getMessage()).build();
+        }
+        catch (Exception e)
+        {
+            log.error("An unexpected exception occurred", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).tag(e.getMessage()).build();
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private Response keyResponse(PropertyKey propertyKey, boolean pretty)
+    {
+        Gson gson;
+        if (pretty)
+            gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
+        else
+            gson = new GsonBuilder().serializeNulls().create();
+
+        JsonObject keyJson = new JsonObject();
+        keyJson.addProperty("key", propertyKey.getKey());
+        keyJson.addProperty("readme", propertyKey.getReadme());
+        keyJson.addProperty("deprecated", propertyKey.isDeprecated());
+        keyJson.addProperty("vdt", propertyKey.getValueDataType().name());
+        keyJson.addProperty("push", propertyKey.isPushValueEnabled());
+
+        Response.ResponseBuilder response = Response.ok(gson.toJson(keyJson), MediaType.APPLICATION_JSON);
+        response.status(200);
+        return response.build();
+    }
+}


### PR DESCRIPTION
Our current use case requires us to grab the data type of a given key
on a regular basis. To reduce load and simplify logic, this commit
exposes an endpoint to get a single key's definition.