### PR TITLE
Making rest/keyData endpoint more user friendly

### DIFF
--- a/rest/src/main/java/com/confighub/api/repository/client/v1/APIPullKeyData.java
+++ b/rest/src/main/java/com/confighub/api/repository/client/v1/APIPullKeyData.java
@@ -119,12 +119,14 @@ public class APIPullKeyData
             gson = new GsonBuilder().serializeNulls().create();
 
         JsonObject keyJson = new JsonObject();
-        keyJson.addProperty("key", propertyKey.getKey());
-        keyJson.addProperty("readme", propertyKey.getReadme());
-        keyJson.addProperty("deprecated", propertyKey.isDeprecated());
-        keyJson.addProperty("vdt", propertyKey.getValueDataType().name());
-        keyJson.addProperty("push", propertyKey.isPushValueEnabled());
-
+        if(null != propertyKey)
+        {
+            keyJson.addProperty("key", propertyKey.getKey());
+            keyJson.addProperty("readme", propertyKey.getReadme());
+            keyJson.addProperty("deprecated", propertyKey.isDeprecated());
+            keyJson.addProperty("vdt", propertyKey.getValueDataType().name());
+            keyJson.addProperty("push", propertyKey.isPushValueEnabled());
+        }
         Response.ResponseBuilder response = Response.ok(gson.toJson(keyJson), MediaType.APPLICATION_JSON);
         response.status(200);
         return response.build();


### PR DESCRIPTION
Changing an error to an empty json response for a
single key data definition rest call when the key
requested does not exist.