### PR TITLE
Add docker support for confighub and fix propertyKey context deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.ipr
 *.iws
 .idea/*
+docker/ConfigHubDBManager.jar

--- a/confighub.Dockerfile
+++ b/confighub.Dockerfile
@@ -1,0 +1,14 @@
+FROM       tomee:8-jre-7.0.6-plume
+
+COPY       docker/layer /
+COPY       docker/ConfigHubDBManager.jar /
+
+RUN        apt-get update && \
+           apt-get -y install \
+               vim \
+               tcpdump \
+               net-tools \
+               mariadb-client
+
+EXPOSE     80 443
+ENTRYPOINT ["/initdev.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "2.2"
+services:
+  confighub:
+    container_name: confighub.dev
+    build:
+      context: .
+      dockerfile: confighub.Dockerfile
+    restart: always
+    ports:
+      - "8080:8080"
+      - "8443:443"
+      - "5080:5080"
+    volumes:
+      - ./rest/target/ROOT.war:/usr/local/tomee/webapps/ROOT.war
+      - ./rest/src/main/webapp/js:/ROOT-js
+    environment:
+      CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5080"
+    links:
+      - database
+  database:
+    container_name: database.dev
+    image: mariadb:10
+    command: mysqld --general-log=1 --general-log-file=/var/log/mysql/mysql.log --skip-networking=0
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: "ConfigHub"
+      MYSQL_USER: "confighub"
+      MYSQL_PASSWORD: "confighub"
+      MYSQL_ROOT_PASSWORD: "root"

--- a/docker/layer/dev-resources.xml
+++ b/docker/layer/dev-resources.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Resources>
+    <Resource id="ConfigHubMainDS" type="DataSource">
+        JdbcDriver=com.mysql.jdbc.Driver
+        JdbcUrl=jdbc:mysql://database:3306/ConfigHub?useSSL=false&amp;autoReconnect=true
+        UserName=confighub
+        Password=confighub
+
+        JtaManaged = false
+        validationQuery="SELECT 1"
+        maxWaitTime = 2 seconds
+        maxActive = 200
+    </Resource>
+</Resources>

--- a/docker/layer/initdev.sh
+++ b/docker/layer/initdev.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+export ALLOCATED_MEMORY=${ALLOCATED_MEMORY:-4g}
+export HTTP_PORT=${HTTP_PORT:-80}
+export HTTPS_PORT=${HTTPS_PORT:-443}
+export LOG_PATH=${LOG_PATH:-/var/log/confighub}
+export KEYSTORE_FILE=${KEYSTORE_FILE:-cert/confighub_default.jks}
+export KEYSTORE_ALIAS=${KEYSTORE_ALIAS:-confighub}
+export KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-confighub}
+
+while ! mysqladmin ping -hdatabase -uconfighub -pconfighub ; do
+  echo "Waiting for mariadb to start..."
+  sleep 1
+done
+# Initialize the database if it hasn't been already done.
+if [[ ! -f /db.init ]] ; then
+  java -jar /ConfigHubDBManager.jar -t mysql -r jdbc:mysql://database:3306/ConfigHub -uconfighub -pconfighub || exit $?
+  touch /db.init
+fi
+
+# Always do this step so the instance always comes up with the latest development package.
+rm -rf /usr/local/tomee/webapps/ROOT || exit $?
+unzip -o /usr/local/tomee/webapps/ROOT.war -d /usr/local/tomee/webapps/ROOT || exit $?
+cp -av /ROOT-js /usr/local/tomee/webapps/ROOT/js || exit $?
+cp -v /dev-resources.xml /usr/local/tomee/webapps/ROOT/WEB-INF/resources.xml || exit $?
+
+catalina.sh run

--- a/docs/pages/schema/push.rst
+++ b/docs/pages/schema/push.rst
@@ -128,10 +128,10 @@ To delete a specific key value:
       "data": [
          {
            "key": "aKey",
-           "values": {
+           "values": [ {
               "context": "el;*;*",
               "opp": "delete"
-           }
+           } ]
          }
       ]
    }


### PR DESCRIPTION
Fixes https://github.com/ConfigHubPub/ConfigHubPlatform/issues/105

During a push-key operation, does not set propertyKey's valueDataField
if propertyKey is not null and if there is a sub-value containing a
delete operation.

Additionally, dockerized development environment.  Initializes
two docker images: database (mariadb-based) and confighub.
Bring them up with "docker-compose build" and then "docker-compose up".
Requires building Database-Manager outside of this project since
that code is not part of this project (yet).