### PR TITLE
Fix bad tomee configuration

### DIFF
--- a/docker/layer/dev-resources.xml
+++ b/docker/layer/dev-resources.xml
@@ -7,7 +7,7 @@
         Password=confighub
 
         JtaManaged = false
-        validationQuery="SELECT 1"
+        validationQuery = SELECT 1
         maxWaitTime = 2 seconds
         maxActive = 200
     </Resource>

--- a/docker/layer/var/tpl/tomee.xml
+++ b/docker/layer/var/tpl/tomee.xml
@@ -7,7 +7,7 @@
         Password = ${DB_PASSWORD}
 
         JtaManaged = false
-        validationQuery="SELECT 1"
+        validationQuery = SELECT 1
         maxWaitTime = 2 seconds
         maxActive = 200
     </Resource>

--- a/docs/pages/getting_started/install.rst
+++ b/docs/pages/getting_started/install.rst
@@ -57,7 +57,7 @@ a database configuration:
            Password = password
 
            JtaManaged = false
-           validationQuery="SELECT 1"
+           validationQuery = SELECT 1
            maxWaitTime = 2 seconds
            maxActive = 200
        </Resource>

--- a/rest/src/test/resources/com/confighub/api/files/sunnyDay1.xml
+++ b/rest/src/test/resources/com/confighub/api/files/sunnyDay1.xml
@@ -8,7 +8,7 @@
         Password = ${ password }
         JtaManaged = false
 
-        validationQuery="SELECT 1"
+        validationQuery = SELECT 1
         maxWaitTime = 2 seconds
         maxActive = 200
     </Resource>

--- a/rest/src/test/resources/com/confighub/api/files/sunnyDay1_resolved.xml
+++ b/rest/src/test/resources/com/confighub/api/files/sunnyDay1_resolved.xml
@@ -8,7 +8,7 @@
         Password = s!e@c#r$e%t^P&a*s(s)w{o}r|d"':;?/>.<,~`
         JtaManaged = false
 
-        validationQuery="SELECT 1"
+        validationQuery = SELECT 1
         maxWaitTime = 2 seconds
         maxActive = 200
     </Resource>


### PR DESCRIPTION
- The configuration file is not a quote encased file, and when turning on
errors for mysql it would result in showcasing the error below as fast as possible
By removing the quotes this error is no longer showing up.

ERROR 1064: You have an error in your SQL syntax; check the manual that corresponds
to your MariaDB server version for the right syntax to use near
'"SELECT 1"' at line 1 : "SELECT 1"