### PR TITLE
set empty list

### DIFF
--- a/core/src/main/java/com/confighub/core/store/Store.java
+++ b/core/src/main/java/com/confighub/core/store/Store.java
@@ -3630,14 +3630,10 @@ public class Store
         if ( null != currentTeam )
         {
             currentTeam.removeMember( member );
-        }
-
-        Team newTeam = addTeamMember( repository, user, toTeam, member );
-        if ( null != currentTeam )
-        {
             saveOrUpdateAudited( user, repository, currentTeam );
         }
 
+        Team newTeam = addTeamMember( repository, user, toTeam, member );
         return newTeam;
     }
 

--- a/rest/src/main/webapp/js/entry.js
+++ b/rest/src/main/webapp/js/entry.js
@@ -616,14 +616,15 @@
                 restrict: "A",
                 templateUrl: 'repo/valueForm.tpl.html',
                 scope: true,
-                controller: ['$scope', '$http', 'secretService', '$httpParamSerializer', 'focus', '$timeout',
-                    function ($scope, $http, secretService, $httpParamSerializer, focus, $timeout)
+                controller: ['$scope', '$http', 'secretService', '$httpParamSerializer', 'focus', '$timeout', '$modal',
+                    function ($scope, $http, secretService, $httpParamSerializer, focus, $timeout, $modal)
                     {
                         $scope.addValueScope($scope);
 
                         $scope.validType = true;
                         $scope.listData = [''];
                         $scope.mapData = [{p: ['','']}];
+                        $scope.oldcontext = null;
 
                         $scope.contextSelectConfig = $scope.canManageContext ? propContextSelectConfig : propContextSelectConfigNoEdit;
 
@@ -769,6 +770,8 @@
                             $scope.context[score] = name;
                         }
 
+                        $scope.previousContext = JSON.parse(JSON.stringify($scope.context))
+
                         // -----------------------------------------------------------------------
                         // Value-Data-Type
                         // -----------------------------------------------------------------------
@@ -904,8 +907,43 @@
                             );
                         };
 
-                        $scope.saveValue = function()
+                        function confirmSave()
                         {
+                            confirm = $modal({
+                                template: '/repo/files/confirmSave.tpl.html',
+                                scope: $scope,
+                                show: false,
+                            });
+                            parentShow = confirm.show;
+                            confirm.show = function() {
+                                $timeout(function () {
+                                    parentShow();
+                                }, 250);
+                                return;
+                            };
+                            return confirm;
+                        }
+
+                        $scope.isMoreSpecificContext = function() {
+                            for (key in $scope.previousContext) {
+                                if (!$scope.previousContext[key] && $scope.context[key]) {
+                                    confirmSave().show();
+                                    return true;
+                                }
+                            }
+                            return false;
+                        };
+
+                        $scope.checkAndSaveValue = function()
+                        {
+                            if ($scope.isMoreSpecificContext()) {
+                                return;
+                            }
+                            $scope.saveValue()
+
+                        };
+
+                        $scope.saveValue = function() {
                             if ($scope.demo) return;
 
                             kd = $scope.getEntryData($scope.side);

--- a/rest/src/main/webapp/js/entry.js
+++ b/rest/src/main/webapp/js/entry.js
@@ -711,6 +711,8 @@
                             {
                                 if (tmpV)
                                     $scope.listData = tmpV;
+                                else
+                                    $scope.listData = [''];
                             }
                             else if (kd.vdt == 'Map')
                             {
@@ -734,6 +736,8 @@
                                 $scope.value = value;
                                 if (value)
                                     $scope.listData = angular.copy(value);
+                                else
+                                    $scope.listData = null;
                             }
                             else if ($scope.entry[$scope.side].vdt == 'Map')
                             {
@@ -908,7 +912,7 @@
 
                             if (kd.vdt == 'List')
                             {
-                                if (!$scope.listData || $scope.listData.length == 0)
+                                if (!$scope.listData)
                                     $scope.value = null;
                                 else
                                     $scope.value = JSON.stringify($scope.listData);

--- a/rest/src/main/webapp/repo/files/confirmSave.tpl.html
+++ b/rest/src/main/webapp/repo/files/confirmSave.tpl.html
@@ -1,0 +1,27 @@
+<div class="modal" tabindex="-1" role="dialog">
+    <form>
+        <div class="modal-dialog narrow-modal">
+            <div class="modal-content">
+
+                <div class="modal-header fyi">
+                    <button type="button" class="big-close" ng-click="$hide()">&times;</button>
+                    <span class="modal-title">
+                    <strong>Heads up!</strong>
+                </span>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group fyi">
+                        If you are seeing this, you are overwriting a star pointing to a property.
+                        Be advised if you proceed, you are not creating a new property value, you will be updating
+                        the context of an existing one potentially leaving the old context value empty.
+                        Please proceed with caution.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-danger" ng-click="$hide();saveValue()">Update context</button>
+                    <button type="button" class="btn btn-default" ng-click="$hide()">Abandon save</button>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>

--- a/rest/src/main/webapp/repo/valueForm.tpl.html
+++ b/rest/src/main/webapp/repo/valueForm.tpl.html
@@ -306,7 +306,7 @@
 
                     <button tabindex="1002"
                             ng-disabled="!validType || (conflict && active) || ut < type.member"
-                            ng-click="saveValue()"
+                            ng-click="checkAndSaveValue()"
                             class="btn btn-success btn-sm">
                         <span ng-if="entry.newProperty">Save property</span>
                         <span ng-if="!entry.newProperty">{{ property.isNew ? 'Add' : 'Update' }} value</span>


### PR DESCRIPTION
Hi Edin, 

This commit fixes a few minor bugs. These are: 
1) change member to new team is currently not doing anything - this change reorders the logic to not throw a MULTIPLE_USER_TEAMS error too early

2) when re-saving a null list value as null without making any other changes in the value editor, the value reverts back to ['']. This is a bug because if you save a null value, it should be null regardless of the value prior. 

3) Can set an empty list as a list value. Currently an empty list gets saved as null, which is contrary to our needs. 