### PR TITLE
Bump version and ensure cache is clear when not caching.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,9 +12,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ConfigHub</groupId>
+    <parent>
+        <artifactId>ConfigHub</artifactId>
+        <groupId>ConfigHub</groupId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ConfigHub-Core</artifactId>
-    <version>1.8.4</version>
     <name>ConfigHub Core</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,14 @@
 
     <groupId>ConfigHub</groupId>
     <artifactId>ConfigHub</artifactId>
-    <version>1.8.4</version>
+    <version>${revision}</version>
     <name>ConfigHub Parent</name>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>
         <module>rest</module>
     </modules>
+    <properties>
+        <revision>1.9.0</revision>
+    </properties>
 </project>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -3,9 +3,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ConfigHub</groupId>
+    <parent>
+        <artifactId>ConfigHub</artifactId>
+        <groupId>ConfigHub</groupId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ConfigHub-Rest</artifactId>
-    <version>1.8.4</version>
     <name>ConfigHub REST</name>
     <packaging>war</packaging>
 
@@ -14,7 +18,7 @@
         <dependency>
             <groupId>ConfigHub</groupId>
             <artifactId>ConfigHub-Core</artifactId>
-            <version>1.8.4</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>

--- a/rest/src/main/java/com/confighub/api/repository/admin/settings/UpdateRepositoryFeatures.java
+++ b/rest/src/main/java/com/confighub/api/repository/admin/settings/UpdateRepositoryFeatures.java
@@ -20,6 +20,7 @@ package com.confighub.api.repository.admin.settings;
 import com.confighub.api.repository.admin.AAdminAccessValidation;
 import com.confighub.api.util.GsonHelper;
 import com.confighub.core.error.ConfigException;
+import com.confighub.core.model.ConcurrentContextPropertiesCache;
 import com.confighub.core.repository.CtxLevel;
 import com.confighub.core.repository.PropertyKey;
 import com.confighub.core.store.Store;
@@ -133,6 +134,11 @@ public class UpdateRepositoryFeatures
             store.begin();
             store.update(repository, user);
             store.commit();
+
+            if (!cachingEnabled)
+            {
+                ConcurrentContextPropertiesCache.getInstance().removeByRepository(repository);  // ensure memory freed when caching disabled
+            }
 
             json.addProperty("success", true);
             json.add("repository", GsonHelper.repositoryToJSON(repository));

--- a/rest/src/main/java/com/confighub/api/repository/client/AClientAccessValidation.java
+++ b/rest/src/main/java/com/confighub/api/repository/client/AClientAccessValidation.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ConcurrentMap;
 public abstract class AClientAccessValidation
 {
     private static final Logger log = LogManager.getFormatterLogger(AClientAccessValidation.class);
-    private static final ConcurrentMap<com.confighub.core.resolver.Context, ImmutableMap<PropertyKey, Property>> contextPropertiesCache = ConcurrentContextPropertiesCache.getInstance();
+    private static final ConcurrentContextPropertiesCache contextPropertiesCache = ConcurrentContextPropertiesCache.getInstance();
 
     @Context
     private HttpServletRequest request;


### PR DESCRIPTION
Bump confighub's version number since the data model has changed.

When caching is disable for a repo, ensure the cache is clear for it so
that there's no unnecessary RAM usage.