### PR TITLE
fix display bug for encrypted properties in audit/revision view

### DIFF
--- a/rest/src/main/webapp/js/audit.js
+++ b/rest/src/main/webapp/js/audit.js
@@ -857,11 +857,20 @@ angular
                                     }).then(function successCallback(response)
                                     {
                                         if (response.data.success) {
-                                            if (revType == 'Delete')
-                                                $scope.oldContent = response.data.value;
-                                            else {
-                                                $scope.oldContent = response.data.old;
-                                                $scope.currContent = response.data.value;
+                                            if (revType == 'Delete') {
+                                                if (angular.isObject(response.data.value) || angular.isArray(response.data.value))
+                                                    $scope.oldContent = JSON.stringify(response.data.value, null, 4).split("\n");
+                                                else
+                                                    $scope.oldContent = response.data.value.split("\n");
+                                            } else {
+                                                if (angular.isObject(response.data.old) || angular.isArray(response.data.old))
+                                                    $scope.oldContent = JSON.stringify(response.data.old, null, 4).split("\n");
+                                                else
+                                                    $scope.oldContent = response.data.old.split("\n");
+                                                if (angular.isObject(response.data.value) || angular.isArray(response.data.value))
+                                                    $scope.currContent = JSON.stringify(response.data.value, null, 4).split("\n");
+                                                else
+                                                    $scope.currContent = response.data.value.split("\n");
                                             }
                                             $scope.encryptionState = 0;
                                         }


### PR DESCRIPTION
In audit/revision view, the encrypted properties are displayed vertically when decrypted.
They must be displayed horizontally

![image](https://user-images.githubusercontent.com/99739050/154079755-70914d05-0c05-44a7-a45b-fbeb8f3e5f4d.png)
![image](https://user-images.githubusercontent.com/99739050/154079786-c601110d-74e9-4c96-bbdd-d589cbeed96c.png)
