### PR TITLE
Update properties context when rename context value

### DIFF
--- a/core/src/main/java/com/confighub/core/store/Store.java
+++ b/core/src/main/java/com/confighub/core/store/Store.java
@@ -1675,8 +1675,6 @@ public class Store
 
             // ToDo: should we save assignments
 
-            saveOrUpdateAudited( user, repository, ctxLevel );
-
             if ( updatePropertyContextStrings )
             {
                 if ( null != ctxLevel.getProperties() )
@@ -1690,6 +1688,7 @@ public class Store
                 }
             }
 
+            saveOrUpdateAudited( user, repository, ctxLevel );
             return ctxLevel;
         }
 


### PR DESCRIPTION
When we update a context value, the value is not updated in the context of concerned properties.
The context of the concerned properties remains with the old value.