### PR TITLE
JSON Key Validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - database
   database:
     container_name: database.dev
-    image: mariadb:10
+    image: mariadb:10.8.2
     command: mysqld --general-log=1 --general-log-file=/var/log/mysql/mysql.log --skip-networking=0 --lower_case_table_names=1
     restart: always
     ports:

--- a/rest/src/main/webapp/js/entry.js
+++ b/rest/src/main/webapp/js/entry.js
@@ -790,7 +790,9 @@
                                 case 'Map':
                                     $scope.validateMap();
                                     break;
-
+                                case 'JSON':
+                                    $scope.validateJson($scope.value);
+                                    break;
                                 default:
                                     $scope.validType = true;
                                     break;
@@ -869,6 +871,28 @@
                             $scope.validType = allGood;
                         };
 
+                        // -----------------------------------------------------------------------
+                        // Value-Data-Type::JSON
+                        // -----------------------------------------------------------------------
+                        $scope.validateJson = function(value)
+                        {
+                            if (null == value)
+                            {
+                                $scope.validType = true;
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    JSON.parse(value);
+                                    $scope.validType = true;
+                                }
+                                catch(e)
+                                {
+                                    $scope.validType = false;
+                                }
+                            }
+                        };
 
                         // -----------------------------------------------------------------------
                         // Navigation

--- a/rest/src/main/webapp/repo/valueForm.tpl.html
+++ b/rest/src/main/webapp/repo/valueForm.tpl.html
@@ -130,6 +130,7 @@
                             <div class="ace-wrapper-value fill"
                                  id="li_{{side}}_{{property.id ? property.id : 'n'}}"
                                  ng-model="$parent.$parent.value"
+                                 ng-change="validateJson(value)"
                                  style="line-height: 18px !important"
                                  ui-ace="{
                                     mode: 'json',


### PR DESCRIPTION
Added a client-side check before creating or updating a JSON key type. If the JSON cannot be parsed (via JSON.parse), the update/create button is disabled.

Also pinned mariadb in docker-compose.yml to 10.8.2 due to this issue https://serverfault.com/questions/1103333/mariadb-10-8-3-in-docker-cant-initialize-timers

closes #49 