### PR TITLE
Fixed bug with JSON editor height

### DIFF
--- a/rest/src/main/webapp/js/entry.js
+++ b/rest/src/main/webapp/js/entry.js
@@ -647,7 +647,7 @@
                                     + editor.renderer.scrollBar.getWidth();
 
                                 if (newHeight > 500)
-                                    return;
+                                    newHeight = 500;
 
                                 e = angular.element(document.querySelector('#li_' + $scope.side + '_' + ($scope.property.id ? $scope.property.id : 'n')));
                                 e.height(newHeight.toString() + "px");


### PR DESCRIPTION
If the JSON was more than 500 pixels tall, the editor wouldn't be resized, making it difficult to edit on a single line